### PR TITLE
Need to include .so files in package data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changes
 ### Added
 
+## v0.1.5
+
+### Fixed
+-Add .so files to package data to Linux/macOS DLL libraries are included in package data
+### Changes
+### Added
+
 
 ## v0.1.4
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="nl5py",
-    version="0.1.4",
+    version="0.1.5",
     author="Donny Zimmanck",
     author_email="dzimmanck@enphaseenergy.com",
     description="Python library for interfacing to the NL5 DLL based circuit simulator",
@@ -29,7 +29,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={
         # Make sure the NL5 DLL is included in the package
-        "": ["*.dll", "*.h", "*.lib"],
+        "": ["*.dll", "*.h", "*.lib", "*.so"],
     },
     install_requires=["numpy", "pandas", "importlib-resources"],
     extras_require={


### PR DESCRIPTION
Small fix for Linux/macOS support.  The .so files for the DLLs were not included in the package data.