### PR TITLE
added filter function

### DIFF
--- a/nl5py/schematic.py
+++ b/nl5py/schematic.py
@@ -261,3 +261,59 @@ class Schematic:
     @check
     def saveas(self, filename):
         NL5_SaveAs(self.circuit, filename.encode())
+    
+    @check
+    def load_filter_params(self, name, b, a, analog=True):
+        """
+        name is the name of the F(s) or F(z) block in the NL5 schematic.
+        b is an array of the numerator values and a is an array of the demonitaor
+        values. Normally these coefficients are calculated using functions from scipy.signal.
+        This function transfers the caclculated coefficients to the NL5 schematic.
+        """
+
+        # Ensure 'analog' is a boolean and either True or False
+        if not isinstance(analog, bool):
+            raise TypeError("analog must be a boolean (True or False).")
+
+        # Ensure 'a' and 'b' are list or numpy array
+        if not isinstance(a, (list, np.ndarray)):
+            raise TypeError("'a' must be a list or numpy array.")
+        if not isinstance(b, (list, np.ndarray)):
+            raise TypeError("'b' must be a list or numpy array.")
+
+        # Ensure 'a' and 'b' have the same length
+        if len(a) != len(b):
+            raise ValueError("'a' and 'b' must have the same length.")
+
+        # Ensure length is between 1 and 5
+        if not (1 <= len(a) <= 5):
+            raise ValueError("Length of 'a' and 'b' must be between 1 and 5.")
+        
+        # Set the model type according to the length of a/b
+        model = "Poly" + str(len(a))
+        self.set_text(name + ".model", model)
+        print(f'model set = {model}')
+        print(f'model read = {self.get_text(name + ".model")}')
+
+       # Set the filter parameters dynamically
+        if analog:
+            # Reverse order for analog
+            for i in range(len(b)):
+                val = b[len(b) - 1 - i]
+                print(f"Setting {name}.b{i} = {val}")
+                self.set_value(f"{name}.b{i}", val)
+            for i in range(len(a)):
+                val = a[len(a) - 1 - i]
+                print(f"Setting {name}.a{i} = {val}")
+                self.set_value(f"{name}.a{i}", val)
+        else:
+            # Normal order for digital
+            for i in range(len(b)):
+                val = b[i]
+                print(f"Setting {name}.b{i} = {val}")
+                self.set_value(f"{name}.b{i}", val)
+            for i in range(len(a)):
+                val = a[i]
+                print(f"Setting {name}.a{i} = {val}")
+                self.set_value(f"{name}.a{i}", val)
+

--- a/tests/filter_tests.nl5
+++ b/tests/filter_tests.nl5
@@ -1,0 +1,247 @@
+<?xml version="1.0"?>
+<NL5>
+  <c>======================================</c>
+  <c> CAUTION: DO NOT MODIFY THIS FILE !!! </c>
+  <c>     ...if you don't know how...      </c>
+  <c>======================================</c>
+  <Version ver="3" rev="19" core="80" build="101" date="04/26/2025" ID="65164210" />
+  <Doc>
+    <Cir mode="2">
+      <Cmps>
+        <Cmp type="F_S" id="3" name="F1" descr="" view="0" node0="1" node1="2" model="Function" f="1" b0="1" b1="0" b2="0" b3="0" b4="0" b5="0" a0="1" a1="0" a2="0" a3="0" a4="0" a5="0" k="1" roots="" table="1%2c1%2c0%2c10%2c10%2c90" file="" ic="" />
+        <Cmp type="F_Z" id="4" name="F2" descr="" view="0" node0="1" node1="4" model="Function" f="1" b0="1" b1="0" b2="0" b3="0" b4="0" b5="0" a0="1" a1="0" a2="0" a3="0" a4="0" a5="0" k="1" roots="" table="1%2c1%2c0%2c10%2c10%2c90" file="" ic="" />
+        <Cmp type="R_R" id="5" name="R1" descr="" view="0" node0="0" node1="2" model="R" r="1e+3" r_txt="1k" />
+        <Cmp type="R_R" id="6" name="R2" descr="" view="0" node0="0" node1="4" model="R" r="1e+3" r_txt="1k" />
+        <Cmp type="V_V" id="2" name="V1" descr="" view="0" node0="0" node1="1" model="V" v="10" />
+      </Cmps>
+      <Sheets activeSheet="0">
+        <Sheet name="Sheet1">
+          <VC size="32" center_x="0" center_y="0" />
+          <Curs p="8,-8" dir="-1" />
+          <Pcts>
+            <Pct type="cmp" id="3" p="-3,-5" dir="0" mir="0" text0="40,-32" text1="40,32" textdir="0" />
+            <Pct type="cmp" id="2" p="-7,-4" dir="1" mir="0" text0="24,-40" text1="42,-40" textdir="0" />
+            <Pct type="cmp" id="4" p="-1,-2" dir="0" mir="0" text0="40,-32" text1="40,32" textdir="0" />
+            <Pct type="cmp" id="5" p="6,-2" dir="1" mir="0" text0="24,-30" text1="40,-30" textdir="0" />
+            <Pct type="cmp" id="6" p="3,-1" dir="1" mir="0" text0="24,-30" text1="40,-30" textdir="0" />
+            <Pct type="dot" p="-4,-5" />
+            <Pct type="gnd" p="-7,-1" dir="1" />
+            <Pct type="gnd" p="6,0" dir="1" />
+            <Pct type="gnd" p="3,1" dir="1" />
+            <Pct type="wire" p0="-7,-5" p1="-4,-5" />
+            <Pct type="wire" p0="-4,-5" p1="-3,-5" />
+            <Pct type="wire" p0="-7,-5" p1="-7,-4" />
+            <Pct type="wire" p0="-4,-5" p1="-4,-2" />
+            <Pct type="wire" p0="0,-5" p1="6,-5" />
+            <Pct type="wire" p0="6,-5" p1="6,-2" />
+            <Pct type="wire" p0="-7,-2" p1="-7,-1" />
+            <Pct type="wire" p0="-4,-2" p1="-1,-2" />
+            <Pct type="wire" p0="2,-2" p1="3,-2" />
+            <Pct type="wire" p0="3,-2" p1="3,-1" />
+          </Pcts>
+        </Sheet>
+      </Sheets>
+      <Win visible="true" floating="false">
+        <Normal state="2" left="52" top="52" width="1608" height="645" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <ComponentsBar visible="true" size="64" />
+    </Cir>
+    <Tran labels="true" selection="false" digital_position="85" advanced_format="false" show_reminder="true">
+      <Traces />
+      <Settings start="0" screen="10" step="1e-3" pause_trigger="false" pause_trigger_f="" start_trigger="false" start_trigger_f="" />
+      <Window>
+        <Win visible="false" floating="false">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+        <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="true" interval="0" left="0" right="1" vert_grid_fixed="false" clip_separated="false" grid_separated="false" />
+        <Legend legend="true" x="950e-3" y="50e-3" />
+        <Scale start="0" screen="1" ys="1" ym="0" vert_mode="0" />
+        <Texts />
+      </Window>
+      <Storage storage="1" last="false" storage_shift="true" />
+      <Cursors left="300e-3" right="600e-3" active="true" locked="false" interval="false" screen="false" />
+      <Table table="false" separate="false" time_header="false" table_cursors="true" table_graph="false">
+        <Items>
+          <Item name="left" en="true" cs="false" width="4" />
+          <Item name="right" en="true" cs="false" width="4" />
+          <Item name="delta" en="true" cs="false" width="4" />
+          <Item name="min" en="true" cs="false" width="4" />
+          <Item name="max" en="true" cs="false" width="4" />
+          <Item name="pp" en="true" cs="false" width="4" />
+          <Item name="mean" en="true" cs="false" width="4" />
+          <Item name="rms" en="true" cs="false" width="4" />
+          <Item name="sd" en="true" cs="false" width="4" />
+          <Item name="freq" en="true" cs="false" width="4" />
+          <Item name="period" en="true" cs="false" width="4" />
+          <Item name="integral" en="true" cs="false" width="4" />
+        </Items>
+      </Table>
+      <Screen status_panels="7" table_height="120" />
+      <Math manual="false" />
+      <Log />
+      <AnalogWindows Maximized="false">
+        <AnalogWindow ratio="1" separated="false" />
+      </AnalogWindows>
+      <TableWindow>
+        <Win visible="false" floating="true">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+      </TableWindow>
+      <Preview Position="40" Left="0" Right="0" />
+    </Tran>
+    <Freq phase="2" phase_ratio="600e-3">
+      <Traces />
+      <Settings type="0" list="" test="" from="1e-3" to="1e+3" points="500" scale="0" id="2" alg="0" dcop="false" faf="0.1" fhl="true" fmr="10" fsh="false" tst="0" fchmin="2" />
+      <Window>
+        <Win visible="false" floating="false">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+        <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="true" interval="0" left="1" right="1e+3" />
+        <Legend legend="true" x="950e-3" y="50e-3" />
+        <Scale pht="180" phb="-180" top="100" bot="100e-6" left="1" right="1e+6" vlog="true" db="true" hlog="true" />
+        <Texts />
+      </Window>
+      <Storage storage="1" last="false" storage_shift="true" />
+      <Cursors left="100" right="10e+3" active="true" locked="false" interval="false" screen="false" />
+      <Table table="false" separate="false" time_header="false" table_cursors="true" table_graph="false">
+        <Items>
+          <Item name="left" en="true" cs="false" width="4" />
+          <Item name="right" en="true" cs="false" width="4" />
+          <Item name="delta" en="true" cs="false" width="4" />
+          <Item name="min" en="true" cs="false" width="4" />
+          <Item name="max" en="true" cs="false" width="4" />
+          <Item name="pp" en="true" cs="false" width="4" />
+          <Item name="slope" en="true" cs="false" width="4" />
+          <Item name="margin" en="true" cs="false" width="4" />
+          <Item name="margin_f" en="true" cs="false" width="4" />
+        </Items>
+      </Table>
+      <Screen status_panels="5" table_height="120" />
+      <Math manual="false" />
+      <Log />
+      <TableWindow>
+        <Win visible="false" floating="true">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+      </TableWindow>
+    </Freq>
+    <Advanced dc="true" sbs="true" to="5" zero="1e-12" ise="false" z0re="50" z0im="0" zparam="" cs="false" s_m="1" s_fs="500e-3" s_ff="1" s_os="125e-3" s_of="250e-3" s_as="15.625e-3" s_af="125e-3" s_cs="125e-3" s_cf="250e-3" css="1e-6" so="false" low="0" high="5" thr="2.5" />
+    <Libraries />
+    <Properties title="No+title" revision="1.0" author="Donny+Zimmanck" project="Unknown" organization="Enphase+Energy" comments="" created="9%2f4%2f2024+11%3a44%3a26+AM" modified="5%2f17%2f2025+9%3a08%3a53+AM" save="0" eng_notation="true" />
+    <CS type="1" x="0" active="true">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale top="1" bot="0" />
+      <Texts />
+    </CS>
+    <XY>
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale xs="1" xm="0" ys="1" ym="0" />
+      <Texts />
+    </XY>
+    <FFT pow="8" win="0" type="1" zp="0" copy="0" tran="0" phase="2" phase_ratio="600e-3">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale top="100" bot="100e-6" left="1" right="1e+6" vlog="true" db="true" hlog="true" pht="180" phb="-180" />
+      <Texts />
+    </FFT>
+    <AH bins="100" from="-1" to="1" interp="false">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale left="-1" right="1" top="1" bot="0" />
+      <Texts />
+    </AH>
+    <DC name="" from="0" to="1" points="100">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale left="0" right="1" ys="1" ym="0" />
+      <Texts />
+    </DC>
+    <ED>
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale ys="1" ym="0" start="0" screen="1" />
+      <Texts />
+    </ED>
+    <Power nh="11">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+    </Power>
+    <FCS type="1" x="0" active="true">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale top="100" bot="100e-6" vlog="true" db="true" />
+      <Texts />
+    </FCS>
+    <Smith status="63" vswr="2%2c3%2c5" z0="50" center="false" zonly="false" show_vswr="false" re_vswr="0" im_vswr="0" grid="0">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale s="1.5" xm="0" ym="0" />
+      <Texts />
+    </Smith>
+    <Nyquist>
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale s="1.5" xm="0" ym="0" />
+      <Texts />
+    </Nyquist>
+    <Sweep name="" from="1.0" to="1.0" step="0.0" type="0" list="" />
+    <Optimization n="4" tran="true" ac="false" run="true">
+      <r0 n="" v="" s="" />
+      <r1 n="" v="" s="" />
+      <r2 n="" v="" s="" />
+      <r3 n="" v="" s="" />
+    </Optimization>
+    <Sheet>
+      <Pcts>
+        <Pct type="pict" pict="3" txt="New NL5 file format not supported">
+          <Font Color="0,255,255" />
+        </Pct>
+      </Pcts>
+    </Sheet>
+  </Doc>
+</NL5>

--- a/tests/filter_tests.nl5~
+++ b/tests/filter_tests.nl5~
@@ -1,0 +1,238 @@
+<?xml version="1.0"?>
+<NL5>
+  <c>======================================</c>
+  <c> CAUTION: DO NOT MODIFY THIS FILE !!! </c>
+  <c>     ...if you don't know how...      </c>
+  <c>======================================</c>
+  <Version ver="3" rev="19" core="80" build="101" date="04/26/2025" ID="266526642" />
+  <Doc>
+    <Cir mode="2">
+      <Cmps>
+        <Cmp type="C_C" id="1" name="C1" descr="" view="0" node0="0" node1="1" model="C" c="1e-9" ic="" />
+        <Cmp type="R_R" id="3" name="R1" descr="" view="0" node0="1" node1="2" model="R" r="1e+3" />
+        <Cmp type="V_V" id="2" name="V1" descr="" view="0" node0="0" node1="2" model="V" v="10" />
+      </Cmps>
+      <Sheets activeSheet="0">
+        <Sheet name="Sheet1">
+          <VC size="32" center_x="0" center_y="0" />
+          <Curs p="-1,1" dir="-1" />
+          <Pcts>
+            <Pct type="cmp" id="3" p="-2,-5" dir="0" mir="0" text0="32,-20" text1="32,20" textdir="0" />
+            <Pct type="cmp" id="2" p="-3,-4" dir="1" mir="0" text0="24,-40" text1="42,-40" textdir="0" />
+            <Pct type="cmp" id="1" p="1,-4" dir="1" mir="0" text0="24,-34" text1="40,-34" textdir="0" />
+            <Pct type="dot" p="-3,-1" />
+            <Pct type="gnd" p="-3,-1" dir="1" />
+            <Pct type="wire" p0="-3,-5" p1="-2,-5" />
+            <Pct type="wire" p0="-3,-5" p1="-3,-4" />
+            <Pct type="wire" p0="0,-5" p1="1,-5" />
+            <Pct type="wire" p0="1,-5" p1="1,-4" />
+            <Pct type="wire" p0="-3,-2" p1="-3,-1" />
+            <Pct type="wire" p0="1,-2" p1="1,-1" />
+            <Pct type="wire" p0="-3,-1" p1="1,-1" />
+          </Pcts>
+        </Sheet>
+      </Sheets>
+      <Win visible="true" floating="false">
+        <Normal state="2" left="52" top="52" width="1608" height="645" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <ComponentsBar visible="true" size="64" />
+    </Cir>
+    <Tran labels="true" selection="false" digital_position="85" advanced_format="false" show_reminder="true">
+      <Traces />
+      <Settings start="0" screen="10" step="1e-3" pause_trigger="false" pause_trigger_f="" start_trigger="false" start_trigger_f="" />
+      <Window>
+        <Win visible="false" floating="false">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+        <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="true" interval="0" left="0" right="1" vert_grid_fixed="false" clip_separated="false" grid_separated="false" />
+        <Legend legend="true" x="950e-3" y="50e-3" />
+        <Scale start="0" screen="1" ys="1" ym="0" vert_mode="0" />
+        <Texts />
+      </Window>
+      <Storage storage="1" last="false" storage_shift="true" />
+      <Cursors left="300e-3" right="600e-3" active="true" locked="false" interval="false" screen="false" />
+      <Table table="false" separate="false" time_header="false" table_cursors="true" table_graph="false">
+        <Items>
+          <Item name="left" en="true" cs="false" width="4" />
+          <Item name="right" en="true" cs="false" width="4" />
+          <Item name="delta" en="true" cs="false" width="4" />
+          <Item name="min" en="true" cs="false" width="4" />
+          <Item name="max" en="true" cs="false" width="4" />
+          <Item name="pp" en="true" cs="false" width="4" />
+          <Item name="mean" en="true" cs="false" width="4" />
+          <Item name="rms" en="true" cs="false" width="4" />
+          <Item name="sd" en="true" cs="false" width="4" />
+          <Item name="freq" en="true" cs="false" width="4" />
+          <Item name="period" en="true" cs="false" width="4" />
+          <Item name="integral" en="true" cs="false" width="4" />
+        </Items>
+      </Table>
+      <Screen status_panels="7" table_height="120" />
+      <Math manual="false" />
+      <Log />
+      <AnalogWindows Maximized="false">
+        <AnalogWindow ratio="1" separated="false" />
+      </AnalogWindows>
+      <TableWindow>
+        <Win visible="false" floating="true">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+      </TableWindow>
+      <Preview Position="40" Left="97" Right="6881367" />
+    </Tran>
+    <Freq phase="2" phase_ratio="600e-3">
+      <Traces />
+      <Settings type="0" list="" test="" from="1e-3" to="1e+3" points="500" scale="0" id="0" alg="0" dcop="false" faf="0.1" fhl="true" fmr="10" fsh="false" tst="0" fchmin="2" />
+      <Window>
+        <Win visible="false" floating="false">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+        <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="true" interval="0" left="1" right="1e+3" />
+        <Legend legend="true" x="950e-3" y="50e-3" />
+        <Scale pht="180" phb="-180" top="100" bot="100e-6" left="1" right="1e+6" vlog="true" db="true" hlog="true" />
+        <Texts />
+      </Window>
+      <Storage storage="1" last="false" storage_shift="true" />
+      <Cursors left="100" right="10e+3" active="true" locked="false" interval="false" screen="false" />
+      <Table table="false" separate="false" time_header="false" table_cursors="true" table_graph="false">
+        <Items>
+          <Item name="left" en="true" cs="false" width="4" />
+          <Item name="right" en="true" cs="false" width="4" />
+          <Item name="delta" en="true" cs="false" width="4" />
+          <Item name="min" en="true" cs="false" width="4" />
+          <Item name="max" en="true" cs="false" width="4" />
+          <Item name="pp" en="true" cs="false" width="4" />
+          <Item name="slope" en="true" cs="false" width="4" />
+          <Item name="margin" en="true" cs="false" width="4" />
+          <Item name="margin_f" en="true" cs="false" width="4" />
+        </Items>
+      </Table>
+      <Screen status_panels="5" table_height="120" />
+      <Math manual="false" />
+      <Log />
+      <TableWindow>
+        <Win visible="false" floating="true">
+          <Normal state="0" left="0" top="0" width="0" height="0" />
+          <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+        </Win>
+      </TableWindow>
+    </Freq>
+    <Advanced dc="true" sbs="true" to="5" zero="1e-12" ise="false" z0re="50" z0im="0" zparam="" cs="false" s_m="1" s_fs="500e-3" s_ff="1" s_os="125e-3" s_of="250e-3" s_as="15.625e-3" s_af="125e-3" s_cs="125e-3" s_cf="250e-3" css="1e-6" so="false" low="0" high="5" thr="2.5" />
+    <Libraries />
+    <Properties title="No+title" revision="1.0" author="Donny+Zimmanck" project="Unknown" organization="Enphase+Energy" comments="" created="9%2f4%2f2024+11%3a44%3a26+AM" modified="9%2f4%2f2024+11%3a45%3a10+AM" save="0" eng_notation="true" />
+    <CS type="1" x="0" active="true">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale top="1" bot="0" />
+      <Texts />
+    </CS>
+    <XY>
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale xs="1" xm="0" ys="1" ym="0" />
+      <Texts />
+    </XY>
+    <FFT pow="8" win="0" type="1" zp="0" copy="0" tran="0" phase="2" phase_ratio="600e-3">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale top="100" bot="100e-6" left="1" right="1e+6" vlog="true" db="true" hlog="true" pht="180" phb="-180" />
+      <Texts />
+    </FFT>
+    <AH bins="100" from="-1" to="1" interp="false">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale left="-1" right="1" top="1" bot="0" />
+      <Texts />
+    </AH>
+    <DC name="" from="0" to="1" points="100">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale left="0" right="1" ys="1" ym="0" />
+      <Texts />
+    </DC>
+    <ED>
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale ys="1" ym="0" start="0" screen="1" />
+      <Texts />
+    </ED>
+    <Power nh="11">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+    </Power>
+    <FCS type="1" x="0" active="true">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale top="100" bot="100e-6" vlog="true" db="true" />
+      <Texts />
+    </FCS>
+    <Smith status="63" vswr="2%2c3%2c5" z0="50" center="false" zonly="false" show_vswr="false" re_vswr="0" im_vswr="0" grid="0">
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale s="1.5" xm="0" ym="0" />
+      <Texts />
+    </Smith>
+    <Nyquist>
+      <Win visible="false" floating="false">
+        <Normal state="0" left="0" top="0" width="0" height="0" />
+        <Floating monitor="0" state="0" left="0" top="0" width="0" height="0" />
+      </Win>
+      <Attributes numbers="true" names="true" annotations="false" vert_grid="true" hor_grid="true" cursors="false" interval="2" left="0" right="1" />
+      <Legend legend="true" x="950e-3" y="50e-3" />
+      <Scale s="1.5" xm="0" ym="0" />
+      <Texts />
+    </Nyquist>
+    <Sweep name="" from="1.0" to="1.0" step="0.0" type="0" list="" />
+    <Optimization n="4" tran="true" ac="false" run="true">
+      <r0 n="" v="" s="" />
+      <r1 n="" v="" s="" />
+      <r2 n="" v="" s="" />
+      <r3 n="" v="" s="" />
+    </Optimization>
+    <Sheet>
+      <Pcts>
+        <Pct type="pict" pict="3" txt="New NL5 file format not supported">
+          <Font Color="0,255,255" />
+        </Pct>
+      </Pcts>
+    </Sheet>
+  </Doc>
+</NL5>


### PR DESCRIPTION
Added a method to schematic class that allows coefficients from filters to be added to NL5 function components F(s) and F(z).   Normally these filter coefficients will be calculated using a library from scipy.signal.  The 'b' coefficients are the numerator of the transfer function for the filter, and the 'a' coefficients are the denominator.  Only the 'ba' format outputs are supported.  The 'sos' and 'zpk' formats are not currently supported.  

The readme file was updated to show a simple example.

pytests were added to verify functionality